### PR TITLE
Fixed PHP-445 (use mongo.default_host with ctor options)

### DIFF
--- a/tests/generic/mongo-ctor-001.phpt
+++ b/tests/generic/mongo-ctor-001.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Mongo::__construct() and INI options
+--SKIPIF--
+<?php require dirname(__FILE__) . "/skipif.inc"; ?>"
+<?php
+if (ini_get("mongo.default_host") == hostname() && ini_get("mongo.default_port") == port()) {
+    exit("SKIP This test is meaningless when connecting to localhost:27017");
+}
+?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$host = hostname();
+$port = port();
+ini_set("mongo.default_host", $host);
+ini_set("mongo.default_port", $port);
+
+$m = new Mongo;
+foreach($m->getHosts() as $s) {
+    if ($s["host"] == $host) {
+        echo "Connected to correct host\n";
+    }
+    if ($s["port"] == $port) {
+        echo "Connected to correct port\n";
+    }
+}
+echo "All done\n";
+?>
+--EXPECT--
+Connected to correct host
+Connected to correct port
+All done
+

--- a/tests/replicaset/mongo-ctor-002.phpt
+++ b/tests/replicaset/mongo-ctor-002.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Mongo::__construct() and $options
+--SKIPIF--
+<?php require dirname(__FILE__) . "/skipif.inc"; ?>"
+<?php
+if (ini_get("mongo.default_host") == hostname() && ini_get("mongo.default_port") == port()) {
+    exit("SKIP This test is meaningless when connecting to localhost:27017");
+}
+?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$host = hostname();
+$port = port();
+ini_set("mongo.default_host", $host);
+ini_set("mongo.default_port", $port);
+
+$opts = array(
+    "replicaSet" => rsname(),
+    "timeout"    => "42",
+    "username"   => array("something"),
+    "password"   => array("else"),
+    "connect"    => "0",
+);
+$m = new Mongo(null, $opts);
+var_dump($opts, $m);
+echo "All done\n";
+?>
+--EXPECTF--
+Notice: Array to string conversion in %smongo-ctor-002.php on line %d
+
+Notice: Array to string conversion in %smongo-ctor-002.php on line %d
+array(5) {
+  ["replicaSet"]=>
+  string(%d) "%s"
+  ["timeout"]=>
+  string(2) "42"
+  ["username"]=>
+  array(1) {
+    [0]=>
+    string(9) "something"
+  }
+  ["password"]=>
+  array(1) {
+    [0]=>
+    string(4) "else"
+  }
+  ["connect"]=>
+  string(1) "0"
+}
+object(Mongo)#%d (4) {
+  ["connected"]=>
+  bool(false)
+  ["status"]=>
+  NULL
+  ["server":protected]=>
+  NULL
+  ["persistent":protected]=>
+  NULL
+}
+All done
+

--- a/tests/utils.inc
+++ b/tests/utils.inc
@@ -95,6 +95,10 @@ function isauth() {
     }
     return (bool)strstr($_ENV["MONGO_SERVER"], "AUTH");
 }
+function rsname($db = null) {
+    m($dsn, $port, $db, $opts);
+    return $opts["replicaSet"];
+}
 function dbname($db = null) {
     m($dsn, $port, $db, $opts);
     return $db;


### PR DESCRIPTION
Also, since we are typehinting now on array we can retrieve an array
from zpp and remove the bc check.
The array values are now converted to their apropriate types to avoid
issues
