### PR TITLE
PHP-1425: Remove error code assertion and always restore notablescan

### DIFF
--- a/tests/generic/bug01425.phpt
+++ b/tests/generic/bug01425.phpt
@@ -17,16 +17,26 @@ $c->drop();
 $c->insert( array( 'foo' => 'bar' ) );
 try
 {
-	$c->find( array( 'foo' => 'bar' ) )->explain();
+    $c->find( array( 'foo' => 'bar' ) )->explain();
+    echo "FAILED: MongoCursorException should have been thrown\n";
 }
 catch ( MongoCursorException $e )
 {
-	echo $e->getCode(), "\n";
-
-	$m->admin->command( array( 'setParameter' => 1, 'notablescan' => 0 ) );
+    // Error message and code vary between server versions, so don't assert their values
+    echo "MongoCursorException was thrown\n";
 }
 
-$m->admin->command( array( 'setParameter' => 1, 'notablescan' => 0 ) );
 ?>
---EXPECT--
-17007
+===DONE===
+--CLEAN--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host);
+$m->admin->command(array('setParameter' => 1, 'notablescan' => 0));
+
+?>
+--EXPECTF--
+MongoCursorException was thrown
+===DONE===


### PR DESCRIPTION
`--CLEAN--` is more reliable than running the command in the `--TEST--` portion (we do this to fix RS states).

Also converted tabs to spaces to be consistent with our other PHP tests.
