### PR TITLE
PHP-1489: Fix test server creation for MongoDB 2.4.x

### DIFF
--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -331,7 +331,8 @@ function initBridge(port, delay) {
         return bridgeTest;
     }
 
-    var bridgePort = allocatePorts(1)[0];
+    // The following is equivalent to: allocatePorts(1, port)[0]
+    var bridgePort = port + 1;
     bridgeTest = startMongoProgram("mongobridge", "--port", bridgePort, "--dest", "localhost:" + port, "--delay", delay);
     bridgeTest.port = bridgePort;
 

--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -185,26 +185,13 @@ function initStandalone(port, auth, root, user) {
 
     if (auth) {
         opts.auth = "";
-        if (/^3\./.test(version())) {
-            opts.setParameter = "authenticationMechanisms=MONGODB-CR,SCRAM-SHA-1";
-        } else if (/^2\.6\./.test(version())) {
-            opts.setParameter = "authenticationMechanisms=MONGODB-CR";
-        }
     }
     if (storageEngine) {
         opts.storageEngine = storageEngine;
     }
     opts.port = port;
 
-    /* Try launching with all interesting mechanisms by default */
-    var retval;
-    try {
-        retval = MongoRunner.runMongod(opts);
-    } catch(e) {
-        delete opts.setParameter;
-        retval = MongoRunner.runMongod(opts);
-    }
-
+    retval = MongoRunner.runMongod(opts);
     retval.port = port;
 
     assert.soon(function() {

--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -8,6 +8,10 @@ var shardTestAuth;
 var bridgeTest;
 var storageEngine;
 
+if (ReplSetTest.getPrimary === undefined) {
+    ReplSetTest.getPrimary = ReplSetTest.getMaster;
+}
+
 function setStorageEngine(engine) {
 	storageEngine = engine;
 }

--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -13,7 +13,7 @@ if (ReplSetTest.getPrimary === undefined) {
 }
 
 function setStorageEngine(engine) {
-	storageEngine = engine;
+    storageEngine = engine;
 }
 
 /**
@@ -194,7 +194,7 @@ function initStandalone(port, auth, root, user) {
     if (storageEngine) {
         opts.storageEngine = storageEngine;
     }
-	opts.port = port;
+    opts.port = port;
 
     /* Try launching with all interesting mechanisms by default */
     var retval;
@@ -393,8 +393,8 @@ function getMasterSlaveConfig(auth) {
  * @return array Is master result
  */
 function getIsMaster() {
-	var info = replTest.getPrimary().getDB("admin").runCommand({ismaster: 1});
-	return [ info.ismaster, info.secondary, info.primary, info.hosts, info.arbiters ];
+    var info = replTest.getPrimary().getDB("admin").runCommand({ismaster: 1});
+    return [ info.ismaster, info.secondary, info.primary, info.hosts, info.arbiters ];
 }
 
 /**
@@ -403,8 +403,8 @@ function getIsMaster() {
  * @return array Is master result
  */
 function getMSIsMaster() {
-	var info = masterSlaveTest.master.getDB('admin').runCommand({ismaster: 1});
-	return [ info.ismaster ];
+    var info = masterSlaveTest.master.getDB('admin').runCommand({ismaster: 1});
+    return [ info.ismaster ];
 }
 
 /**
@@ -538,15 +538,15 @@ function _addUser(conn, loginUser, newUser) {
 }
 
 function makeAdminUser(db, username, password) {
-	adminroles = [ { role: "readWrite",       db: "test" },
-	               "root", "clusterAdmin", "readWrite", "readAnyDatabase"
-	             ];
-	adminroles = [ "root" ];
-	return makeUser(db, username, password, adminroles);
+    adminroles = [ { role: "readWrite",       db: "test" },
+                   "root", "clusterAdmin", "readWrite", "readAnyDatabase"
+                 ];
+    adminroles = [ "root" ];
+    return makeUser(db, username, password, adminroles);
 }
 function makeNormalUser(db, username, password) {
-	normalroles = [ "readWrite", "dbAdmin" ];
-	return makeUser(db, username, password, normalroles);
+    normalroles = [ "readWrite", "dbAdmin" ];
+    return makeUser(db, username, password, normalroles);
 }
 function makeUser(db, username, password, roles) {
     try {

--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -185,7 +185,11 @@ function initStandalone(port, auth, root, user) {
 
     if (auth) {
         opts.auth = "";
-        opts.setParameter = "authenticationMechanisms=MONGODB-CR,SCRAM-SHA-1";
+        if (/^3\./.test(version())) {
+            opts.setParameter = "authenticationMechanisms=MONGODB-CR,SCRAM-SHA-1";
+        } else if (/^2\.6\./.test(version())) {
+            opts.setParameter = "authenticationMechanisms=MONGODB-CR";
+        }
     }
     if (storageEngine) {
         opts.storageEngine = storageEngine;

--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -67,7 +67,8 @@ function initRS(servers, port, rsSettings, keyFile, root, user) {
             "nopreallocj": "",
             "quiet": "",
             "oplogSize": 10,
-            "logpath": "/tmp/NODE." + (keyFile ? "-AUTH" : "") + i
+            "logpath": "/tmp/NODE." + (keyFile ? "-AUTH" : "") + i,
+            "nohttpinterface": ""
         };
 
         if (storageEngine) {
@@ -137,7 +138,8 @@ function initMasterSlave(port) {
     masterOptions = {
         "oplogSize": 10,
         "ipv6": "",
-        "logpath": "/tmp/NODE.MS.master"
+        "logpath": "/tmp/NODE.MS.master",
+        "nohttpinterface": ""
     };
 
     if (storageEngine) {
@@ -177,7 +179,8 @@ function initStandalone(port, auth, root, user) {
 
     var opts = {
         "dbpath" : MongoRunner.dataPath + port,
-        "ipv6": ""
+        "ipv6": "",
+        "nohttpinterface": ""
     };
 
     if (auth) {
@@ -247,7 +250,8 @@ function initShard(mongoscount, rsOptions, rsSettings) {
         "logpath": "/tmp/NODE.RS",
         "useHostname": false,
         "useHostName": false,
-        "oplogSize": 10
+        "oplogSize": 10,
+        "nohttpinterface": ""
     }
 
     shardOptions = {
@@ -262,7 +266,8 @@ function initShard(mongoscount, rsOptions, rsSettings) {
         "other": {
             "mongosOptions": {
                 "ipv6": "",
-                "logpath": "/dev/null"
+                "logpath": "/dev/null",
+                "nohttpinterface": ""
             }
         }
     }


### PR DESCRIPTION
For inclusion with https://github.com/mongodb/mongo-php-driver-legacy/pull/879

I've tested that the test framework launches properly for 2.4.14, 2.6.12, 3.0.12, and 3.2.6. There are test failures, but that may be because the original PR is not rebased to include test fixes for PHP-1510. See: 
- https://github.com/mongodb/mongo-php-driver-legacy/pull/876
- https://github.com/mongodb/mongo-php-driver-legacy/pull/877
